### PR TITLE
Minor Additions to Quick Start

### DIFF
--- a/quick-start/1.markdown
+++ b/quick-start/1.markdown
@@ -39,7 +39,8 @@ With the dependencies installed, we're now ready to build LFE.
 
 Ordinarily, only the ```make``` command would be necessary. However, there's
 currently <a href="https://github.com/rvirding/lfe/issues/14">an issue</a> with
-the ```Makefile``` that temporarily requires that first step.
+the ```Makefile``` that temporarily requires that first step. Ignore the
+warnings.
 
 #### 1.2.2 Using ```rebar```
 
@@ -50,19 +51,24 @@ Alternatively, one may use ```rebar``` to build LFE:
 
 ### 1.3 Installing
 
-On non-development systems, or any system where you don't want to run LFE from
-a git checkout, installing system-wide is the preferred way to use LFE. If you
-set your ```$ERL_LIBS``` environment variable, LFE will install there. Here's
-how one might do this on a Mac OS X system with Erlang installed by
-<a href="http://mxcl.github.com/homebrew/">Homebrew</a>:
+Now install: on non-development systems, or any system where you don't want to
+run LFE from a git checkout, installing system-wide is the preferred way to use
+LFE. If youset your ```$ERL_LIBS``` environment variable, LFE will install
+there. Here's how one might do this on a Mac OS X system with Erlang installed
+by <a href="http://mxcl.github.com/homebrew/">Homebrew</a>:
 
     $ export ERL_LIBS=/usr/local/lib/erlang/lib
     $ make install
 
-You can then check that everything is where you expect:
+And this works for <a href="http://www.macports.org">macports</a>:
+
+    $ export ERL_LIBS=/opt/local/lib/erlang/lib
+    $ sudo -E bash -c "make install"
+
+You can then check that everything is where it should be:
 
     $ ls -1 $ERL_LIBS|grep lfe
-    lfe-0.7
+    lfe
 
 Now you can use LFE from anywhere:
 {% highlight erlang %}


### PR DESCRIPTION
#### Rational for "now install:"

I for one skipped install after glancing over the start of the original sentence, taking away that the paragraph was an alternate for deployed systems. Yes I overlooked the sub headline reading 'installing' and did not think. But it's the **quick** install guide.
#### Rational for Macports

Again, it's the quick install guide -- and it took me pretty long to figure what was not working and unearth the needed syntax for sudo, after finding the right path. In these fleeting times I almost gave up on giving LFE a whirl. It was compounded, I believe with an error in the Makefile, which runs `mkdir -p $(INSTALLDIR);$(BINDIR)` with the BINDIR being out of place in that line.
#### Commit message

_quick install markdown: added encouragement to ignore make warnings; added clarification that install is needed; added Macports install command line; corrected result of "ls -1 $ERL_LIBS|grep lfe": lfe;_
