### PR TITLE
Fix curl commands

### DIFF
--- a/downloads/quick-start.md
+++ b/downloads/quick-start.md
@@ -32,7 +32,7 @@ details.
 Let's get started: install ``lfetool``!
 
 ```bash
-$ curl -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
+$ curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
 $ bash lfetool install /usr/local/bin
 ```
 

--- a/quick-start/1.md
+++ b/quick-start/1.md
@@ -29,7 +29,7 @@ details.
 Let's get started: install ``lfetool``!
 
 ```bash
-$ curl -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
+$ curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
 $ bash lfetool install /usr/local/bin
 ```
 

--- a/user-guide/devops/1.md
+++ b/user-guide/devops/1.md
@@ -19,7 +19,7 @@ step.
 ### 9.1.2 Installation
 
 ```bash
-$ curl -O https://raw.github.com/wiki/rebar/rebar/rebar
+$ curl -L -O https://raw.github.com/wiki/rebar/rebar/rebar
 $ mv rebar /usr/local/bin/
 $ chmod a+x /usr/local/bin/rebar
 ```

--- a/user-guide/devops/2.md
+++ b/user-guide/devops/2.md
@@ -18,7 +18,7 @@ There's more good stuff on that page.
 Installation is a piece of cake:
 
 ```bash
-$ curl -O https://raw.github.com/spawngrid/kerl/master/kerl
+$ curl -L -O https://raw.github.com/spawngrid/kerl/master/kerl
 $ mv kerl /usr/local/bin/
 $ chmod a+x /usr/local/bin/kerl
 ```

--- a/user-guide/intro/4.md
+++ b/user-guide/intro/4.md
@@ -50,7 +50,7 @@ get it set up.
 Here's how to download and install it:
 
 ```bash
-$ curl -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
+$ curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
 $ bash lfetool install /usr/local/bin
 ```
 


### PR DESCRIPTION
Sometime apparently very recently, Github changed the hostname for grabbing content from projects from `raw.github.com` to `raw.githubusercontent.com`.

This broke the `curl` commands in use in the docs because they did not use `-L` to follow redirects. Images continue to work because the browser will chase the redirect.

Rather than fix the hostname everywhere, which isn't a bad idea, I just added `-L` to all invocations of `curl`.

(Looks like vim added an end of line to the end of `quick-start.md` as well.)
