### PR TITLE
check-no-deps does not exist

### DIFF
--- a/downloads/quick-start.md
+++ b/downloads/quick-start.md
@@ -151,7 +151,7 @@ to this:
 Now re-run the unit tests:
 
 ```bash
-$ make check-no-deps
+$ make check-unit
 ```
 
 And you should get a passing test:
@@ -251,9 +251,6 @@ Sure thing :-) Just do this from your new LFE project directory:
 ```bash
 make shell-no-deps
 ```
-
-(There's that ``-no-deps`` thing again... don't worry, we're going to tell
-you about it.)
 
 This should give you something that looks like the following:
 
@@ -381,7 +378,7 @@ you can skip the deps with the following targets:
 
 * ``compile-no-deps``
 * ``shell-no-deps``
-* ``check-no-deps``
+* ``check-unit``
 
 There are other interesting ``make`` targets tucked in the ``Makefile``, and
 you can learn more about how to manage LFE projects by checking them out.

--- a/quick-start/2.md
+++ b/quick-start/2.md
@@ -72,7 +72,7 @@ to this:
 Now re-run the unit tests:
 
 ```bash
-$ make check-no-deps
+$ make check-unit
 ```
 
 And you should get a passing test:

--- a/quick-start/3.md
+++ b/quick-start/3.md
@@ -24,9 +24,6 @@ Sure thing :-) Just do this from your new LFE project directory:
 make shell-no-deps
 ```
 
-(There's that ``-no-deps`` thing again... don't worry, we're going to tell
-you about it.)
-
 This should give you something that looks like the following:
 
 ```cl

--- a/quick-start/4.md
+++ b/quick-start/4.md
@@ -35,7 +35,7 @@ you can skip the deps with the following targets:
 
 * ``compile-no-deps``
 * ``shell-no-deps``
-* ``check-no-deps``
+* ``check-unit``
 
 There are other interesting ``make`` targets tucked in the ``Makefile``, and
 you can learn more about how to manage LFE projects by checking them out.


### PR DESCRIPTION
The quickstart refers to `check-no-deps`, but that does not appear in the `common.mk` file I have with the latest release of `lfetool`. On the assumption that this is outdated (or simply wrong) I updated all references to use `check-unit` instead, which appears to be the desired invocation.
