### PR TITLE
fixes #96: hackaround adding img-fluid class for img responsiveness

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -106,7 +106,7 @@ lfe>
 ```
 '''
 code = '''
-![repl image](/images/repl.png)
+![repl image mobile](/images/repl.png)
 '''
 desc = '''
 LFE comes with a powerful REPL, supporting interactive development
@@ -627,7 +627,7 @@ title = "Give yourself to the Lisp-side of the Force!"
 content = '''
 [img-src]: /images/xkcd-lisp-cycles.png
 [img-link]: http://xkcd.com/297/
-[![call-out content][img-src]][img-link]
+[![call-out content mobile][img-src]][img-link]
 '''
 
 ###   Sponsors Section   ###############################

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,2 @@
+// add 'mobile' to the alt attribute to apply Bootstrap's img-fluid for responsiveness
+$('img[alt~="mobile"]').addClass('img-fluid')

--- a/templates/base/end-scripts.html
+++ b/templates/base/end-scripts.html
@@ -3,6 +3,7 @@
 <script type="text/javascript" src="/search_index.en.js"></script>
 <script type="text/javascript" src="/js/bootstrap.bundle.min.js"></script>
 <script type="text/javascript" src="/js/search.js"></script>
+<script type="text/javascript" src="/js/app.js"></script>
 <script type="text/javascript" src="/js/highlight.js"></script>
 <script>
     hljs.initHighlightingOnLoad();


### PR DESCRIPTION
Super hacky... but I wasn't sure how to add classes to the images easily. Let me know if I am missing something!

- [x] adds mobile to alt for images we want the .img-fluid applied to

**Loom**: https://www.loom.com/share/f0723183c23d474ebf93ea9fb3694549